### PR TITLE
修复needLogin非function错误

### DIFF
--- a/lib/userauth.js
+++ b/lib/userauth.js
@@ -139,11 +139,17 @@ module.exports = function userauth(match, options) {
   options.getUser = options.getUser;
 
   var needLogin = match;
+  
+  if (typeof match === 'string') {
+    match = new RegExp('^' + match);
+  }
 
   if (match instanceof RegExp) {
     needLogin = function (pathname, req) {
       return match.test(pathname);
     };
+  } else if (typeof match !== 'function') {
+    needLogin = function () {};
   }
 
   var defaultLoginCallback = function (req, user, callback) {


### PR DESCRIPTION
当传入的路径匹配规则非正则时needLogin(path, req) 就不对了。
